### PR TITLE
Fix issue with file_get_contents and add action tag documentation

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -50,11 +50,13 @@ class ExternalModule extends AbstractExternalModule {
             $row = $this->getDefaultConfig($display_mode);
             $row['field'] = $field_name;
 
-            $b64 = base64_encode(file_get_contents(dirname(__FILE__) . '/' . $row['image']));
+            $dir = $this->getModulePath();
+
+            $b64 = base64_encode(file_get_contents($dir . $row['image']));
             $src = "data:image/png;base64,$b64";
             $row['src'] = $src;
 
-            $row['areas'] = file_get_contents(dirname(__FILE__) . '/' .  $row['map']);
+            $row['areas'] = file_get_contents($dir .  $row['map']);
             $row['type'] = $field_info['element_type'];
 
             $settings[] = $row;

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -46,8 +46,6 @@ class ExternalModule extends AbstractExternalModule {
             if (!$display_mode = Form::getValueInActionTag($field_info['misc'], '@IMAGEMAP')) {
                 continue;
             }
-
-            //print_r($field_info);
             
             $row = $this->getDefaultConfig($display_mode);
             $row['field'] = $field_name;

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -52,11 +52,11 @@ class ExternalModule extends AbstractExternalModule {
             $row = $this->getDefaultConfig($display_mode);
             $row['field'] = $field_name;
 
-            $b64 = base64_encode(file_get_contents($this->getUrl($row['image'])));
+            $b64 = base64_encode(file_get_contents(dirname(__FILE__) . '/' . $row['image']));
             $src = "data:image/png;base64,$b64";
             $row['src'] = $src;
 
-            $row['areas'] = file_get_contents($this->getUrl($row['map']));
+            $row['areas'] = file_get_contents(dirname(__FILE__) . '/' .  $row['map']);
             $row['type'] = $field_info['element_type'];
 
             $settings[] = $row;

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Pain Map",
     "namespace": "PainMap\\ExternalModule",
-    "description": "Provides a graphical method of surveying a participant's experience of pain by providing an easy way to indicate painful body parts as well as levels of pain. The survey participant is able to select the image representing the user's current pain level or by clicking predetermined regions in a diagram of the human body. To use this module, use the @IMAGEMAP action tag with the appropriate value in a Text Box field: <br> <br> <div style='color:red;'>&nbsp;&nbsp;@IMAGEMAP = PAINMAP_MALE<br> &nbsp;&nbsp;@IMAGEMAP = PAINMAP_FEMALE<br> &nbsp;&nbsp;@IMAGEMAP = SMILE_SCALE</div><br>See the complete <b><a href='https://github.com/ctsit/painmap/tree/1.0.0' target='_blank'>documentation</a></b> at <a href='https://github.com/ctsit/painmap/tree/1.0.0' target='_blank'>https://github.com/ctsit/painmap/tree/1.0.0</a>.",
+    "description": "Provides a graphical method of surveying a participant's experience of pain by providing an easy way to indicate painful body parts as well as levels of pain. The survey participant is able to select the image representing the user's current pain level or by clicking predetermined regions in a diagram of the human body. To use this module, use the @IMAGEMAP action tag with the appropriate value in a Text Box field: <br> <br> <div style='color:red;'>&nbsp;&nbsp;@IMAGEMAP = PAINMAP_MALE<br> &nbsp;&nbsp;@IMAGEMAP = PAINMAP_FEMALE<br> &nbsp;&nbsp;@IMAGEMAP = SMILE_SCALE</div><br> See the complete <b><a href='https://github.com/ctsit/painmap' target='_blank'>documentation</a></b> at <a href='https://github.com/ctsit/painmap' target='_blank'>https://github.com/ctsit/painmap</a>.",
     "permissions": [
         "redcap_every_page_top"
     ],

--- a/js/helper.js
+++ b/js/helper.js
@@ -23,7 +23,7 @@ $(document).ready(function() {
         }
 
         var tag_name = '@IMAGEMAP';
-        var descr = 'TODO.';
+        var descr = 'Converts a Text Box field into one of the following clickable images: male, female, or smile scale. The possible values for @IMAGEMAP are PAINMAP_FEMALE, PAINMAP_MALE, and SMILE_SCALE corresponding to a generic female body, a generic male body, and a smile scale, respectively. For example, to display a male body with clickable body parts, you may use @IMAGEMAP=PAINMAP_MALE.';
 
         // Creating a new action tag row.
         var $new_action_tag = $default_action_tag.clone();


### PR DESCRIPTION
Main changes:
- `file_get_content` was not working with a url as an input. Fixed issue by changing the url by a dir path using ExternalModules method `getModulePath()`.
-  Added action tag documentation (to appear in the action tag info pop up).

What to test:
- Action tag should be working (image is displayed and body parts are clickable).
- Review action tag documentation.